### PR TITLE
add sidebar with dashboard components and routing

### DIFF
--- a/client/src/components/Navbar.vue
+++ b/client/src/components/Navbar.vue
@@ -1,16 +1,78 @@
 <template>
-  <v-app>
+  <nav>
+    <v-navigation-drawer v-model="drawer" app color="primary" dark>
+      <v-list-item>
+        <v-list-item-avatar>
+          <v-img class="img-round"></v-img>
+        </v-list-item-avatar>
+
+        <v-list-item-content>
+          <v-list-item-title>Username</v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+
+      <v-divider></v-divider>
+
+      <v-list dense>
+        <v-list-item
+          v-for="item in items"
+          :key="item.title"
+          :to="item.route"
+          link
+        >
+          <!-- <v-list-item-icon>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-icon> -->
+
+          <v-list-item-content>
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-navigation-drawer>
     <v-app-bar app color="primary" dark>
-      <h2 class="font-weight-medium">Interview Management</h2>
-      <v-spacer></v-spacer>
+      <v-app-bar-nav-icon @click="toggleSideBar"></v-app-bar-nav-icon>
+      <v-toolbar-title style="cursor: pointer" @click="navigateHome"
+        >Interview Managment</v-toolbar-title
+      >
     </v-app-bar>
-  </v-app>
+  </nav>
 </template>
 
 <script>
 export default {
-  name: "Navbar",
-
-  data: () => ({}),
+  data() {
+    return {
+      drawer: false,
+      items: [
+        {
+          title: "Admin Dashboard",
+          route: "/admin-dashboard",
+        },
+        {
+          title: "Interviewer Dashboard",
+          route: "/interviewer-dashboard",
+        },
+        {
+          title: "Candidate Dashboard",
+          route: "/candidate-dashboard",
+        },
+      ],
+    };
+  },
+  methods: {
+    toggleSideBar() {
+      this.drawer = !this.drawer;
+    },
+    navigateHome() {
+      this.$router.push("/");
+    },
+  },
 };
 </script>
+<style>
+.img-round {
+  border: 1px solid grey;
+  background-color: #ccc;
+}
+</style>

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -1,23 +1,32 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-import HomeView from "../views/Home.vue";
+import HomePage from "../views/HomePage.vue";
+import AdminDashboard from "../views/AdminDashboard.vue";
+import InterviewerDashboard from "../views/InterviewerDashboard.vue";
+import CandidateDashboard from "../views/CandidateDashboard.vue";
 
 Vue.use(VueRouter);
 
 const routes = [
   {
     path: "/",
-    name: "home",
-    component: HomeView,
+    name: "HomePage",
+    component: HomePage,
   },
   {
-    path: "/about",
-    name: "about",
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () =>
-      import(/* webpackChunkName: "about" */ "../views/About.vue"),
+    path: "/admin-dashboard",
+    name: "AdminDashboard",
+    component: AdminDashboard,
+  },
+  {
+    path: "/interviewer-dashboard",
+    name: "InterviewerDashboard",
+    component: InterviewerDashboard,
+  },
+  {
+    path: "/candidate-dashboard",
+    name: "CandidateDashboard",
+    component: CandidateDashboard,
   },
 ];
 

--- a/client/src/views/About.vue
+++ b/client/src/views/About.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="about">
-    <h1>This is an about page</h1>
-  </div>
-</template>

--- a/client/src/views/AdminDashboard.vue
+++ b/client/src/views/AdminDashboard.vue
@@ -1,11 +1,14 @@
 <template>
-  <Navbar />
+  <div class="d-flex justify-center align-center mt-5">
+    <Navbar />
+    <h1>Admin dashboard</h1>
+  </div>
 </template>
 
 <script>
 import Navbar from "../components/Navbar";
 export default {
-  name: "Home",
+  name: "AdminDasboard",
   components: {
     Navbar,
   },

--- a/client/src/views/CandidateDashboard.vue
+++ b/client/src/views/CandidateDashboard.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex justify-center align-center mt-5">
+    <Navbar />
+    <h1>Candidate dashboard</h1>
+  </div>
+</template>
+
+<script>
+import Navbar from "../components/Navbar.vue";
+export default {
+  name: "CandidateDashboard",
+  components: {
+    Navbar,
+  },
+};
+</script>

--- a/client/src/views/HomePage.vue
+++ b/client/src/views/HomePage.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex justify-center align-center mt-5">
+    <Navbar />
+    <h1>Landing Page / Login</h1>
+  </div>
+</template>
+
+<script>
+import Navbar from "../components/Navbar.vue";
+export default {
+  name: "HomePage",
+  components: {
+    Navbar,
+  },
+};
+</script>

--- a/client/src/views/InterviewerDashboard.vue
+++ b/client/src/views/InterviewerDashboard.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="d-flex justify-center align-center mt-5">
+    <Navbar />
+    <h1>Interviewer dashboard</h1>
+  </div>
+</template>
+
+<script>
+import Navbar from "../components/Navbar.vue";
+export default {
+  name: "InterviewerDashboard",
+  components: {
+    Navbar,
+  },
+};
+</script>


### PR DESCRIPTION
Created a basic skeleton for the dashboard and overall frontend app to get started with.
- Added a `navbar`  component with side-bar which activates on toggle.
- Added 3 dashboard skeleton.
- Added routing to navigate between the `home page` , `admin` , `candidate` and `interviewer dashboards`. 

![image](https://user-images.githubusercontent.com/22442931/194151467-fd39525b-b31f-4c45-a1d9-b4fe1013f985.png)
